### PR TITLE
feat(scaler): add noop scaler

### DIFF
--- a/cmd/waymond/main.go
+++ b/cmd/waymond/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/scriptnull/waymond/internal/log"
 	"github.com/scriptnull/waymond/internal/scaler"
 	"github.com/scriptnull/waymond/internal/scaler/docker"
+	"github.com/scriptnull/waymond/internal/scaler/noop"
 	"github.com/scriptnull/waymond/internal/trigger"
 	"github.com/scriptnull/waymond/internal/trigger/buildkite"
 	"github.com/scriptnull/waymond/internal/trigger/cron"
@@ -83,6 +84,7 @@ func main() {
 	// track available trigger configuration parsers available out of the box in waymond
 	scalerConfigParsers := make(map[scaler.Type]func(*koanf.Koanf) (scaler.Interface, error))
 	scalerConfigParsers[docker.Type] = docker.ParseConfig
+	scalerConfigParsers[noop.Type] = noop.ParseConfig
 
 	// extract scalers from scaler configurations
 	scalerConfigs := k.Slices("scaler")

--- a/examples/cron-buildkite.toml
+++ b/examples/cron-buildkite.toml
@@ -18,3 +18,13 @@ type = "direct"
 id = "check_my_buildkite_org_queues_periodically"
 from = "trigger.global_cron"
 to = "trigger.my_buildkite_org"
+
+[[scaler]]
+type = "noop"
+id = "noop"
+
+[[connect]]
+type = "direct"
+id = "print_trigger_output"
+from = "trigger.my_buildkite_org"
+to = "scaler.noop"

--- a/internal/scaler/noop/noop.go
+++ b/internal/scaler/noop/noop.go
@@ -1,0 +1,46 @@
+package noop
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/knadh/koanf/v2"
+	"github.com/scriptnull/waymond/internal/event"
+	"github.com/scriptnull/waymond/internal/log"
+	"github.com/scriptnull/waymond/internal/scaler"
+)
+
+const Type scaler.Type = "noop"
+
+type Scaler struct {
+	id           string
+	namespacedID string
+
+	log log.Logger
+}
+
+func (s *Scaler) Type() scaler.Type {
+	return Type
+}
+
+func (s *Scaler) Register(ctx context.Context) error {
+	event.B.Subscribe(fmt.Sprintf("%s.input", s.namespacedID), func(data []byte) {
+		s.log.Verbose("data = ", string(data))
+	})
+	return nil
+}
+
+func ParseConfig(k *koanf.Koanf) (scaler.Interface, error) {
+	id := k.String("id")
+	if id == "" {
+		return nil, errors.New("expected non-empty value for 'id' in docker scaler")
+	}
+
+	s := &Scaler{
+		id:           id,
+		namespacedID: fmt.Sprintf("scaler.%s", id),
+	}
+	s.log = log.New(s.namespacedID)
+	return s, nil
+}

--- a/internal/scaler/noop/noop.go
+++ b/internal/scaler/noop/noop.go
@@ -27,6 +27,7 @@ func (s *Scaler) Type() scaler.Type {
 func (s *Scaler) Register(ctx context.Context) error {
 	event.B.Subscribe(fmt.Sprintf("%s.input", s.namespacedID), func(data []byte) {
 		s.log.Verbose("data = ", string(data))
+		event.B.Publish(fmt.Sprintf("%s.output", s.namespacedID), data)
 	})
 	return nil
 }

--- a/site/docs/scalers/noop.md
+++ b/site/docs/scalers/noop.md
@@ -1,0 +1,52 @@
+---
+sidebar_position: 2
+---
+
+# No-op
+
+No-op stands for ["No operation"](https://en.wikipedia.org/wiki/NOP_(code)). No-op scaler is used for debugging purposes. It doesn't do anything other than logging the event data received from the triggers connected to it.
+
+
+## Configuration
+
+```toml
+[[scaler]]
+type = "noop"
+id = "<choose a name>"
+```
+
+## Example
+
+The following waymond config would periodically trigger the `buildkite` trigger. The events from buildkite trigger will not be used to perform any autoscaling operation. Instead, the noop scaler connected to it will log all the event data in waymond logs.
+
+```toml
+[[trigger]]
+type = "cron"
+id = "global_cron"
+expression = "*/1 * * * *"
+
+[[trigger]]
+type = "buildkite"
+id = "my_buildkite_org"
+# set BUILDKITE_TOKEN environment variable
+
+[[connect]]
+type = "direct"
+id = "check_my_buildkite_org_queues_periodically"
+from = "trigger.global_cron"
+to = "trigger.my_buildkite_org"
+
+[[scaler]]
+type = "noop"
+id = "noop"
+
+[[connect]]
+type = "direct"
+id = "print_trigger_output"
+from = "trigger.my_buildkite_org"
+to = "scaler.noop"
+```
+
+## Events
+
+Emits `scaler.<id>.output` event that produces the same data received in the noop scaler as the input via `scaler.<id>.input` event.


### PR DESCRIPTION
Doing this to unblock #5 

# No-op

No-op stands for ["No operation"](https://en.wikipedia.org/wiki/NOP_(code)). No-op scaler is used for debugging purposes. It doesn't do anything other than logging the event data received from the triggers connected to it.


## Configuration

```toml
[[scaler]]
type = "noop"
id = "<choose a name>"
```

Refer docs file for more info.