### PR TITLE
feat: subscribe to the correct event name when registering a docker scaler

### DIFF
--- a/internal/scaler/docker/docker.go
+++ b/internal/scaler/docker/docker.go
@@ -37,7 +37,7 @@ func (s *Scaler) Register(ctx context.Context) error {
 	}
 	cli.NegotiateAPIVersion(ctx)
 
-	event.B.Subscribe(s.namespacedID, func(_ []byte) {
+	event.B.Subscribe(fmt.Sprintf("%s.input", s.namespacedID), func(_ []byte) {
 		s.log.Verbose("start")
 
 		imageFullName := fmt.Sprintf("%s:%s", s.imageName, s.imageTag)


### PR DESCRIPTION
@scriptnull This is a great project! 

I noticed a typo in the Docker scaler. The event name that the scaler must subscribe to should be:
```go
fmt.Sprintf("%s.input", s.namespacedID)
```
instead of:
```go
s.namespacedID
``` 
This PR addresses that issue.