### PR TITLE
feat: validate if config is a DAG

### DIFF
--- a/cmd/waymond/dag_validation_test.go
+++ b/cmd/waymond/dag_validation_test.go
@@ -1,0 +1,258 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/knadh/koanf/parsers/toml"
+	"github.com/knadh/koanf/providers/rawbytes"
+	"github.com/knadh/koanf/v2"
+	"github.com/scriptnull/waymond/internal/connector"
+	"github.com/scriptnull/waymond/internal/connector/direct"
+)
+
+const testcase1 = `[[trigger]]
+type = "cron"
+id = "global_cron"
+expression = "*/1 * * * *"
+
+[[trigger]]
+type = "buildkite"
+id = "my_buildkite_org"
+filter_by_queue_name = "aws-on-demand-arm64-ubuntu-.*-ami-.*"
+# set BUILDKITE_TOKEN environment variable
+
+[[connect]]
+type = "direct"
+id = "check_my_buildkite_org_queues_periodically"
+from = "trigger.global_cron"
+to = "trigger.my_buildkite_org"
+
+[[scaler]]
+type = "noop"
+id = "noop"
+
+[[connect]]
+type = "direct"
+id = "print_trigger_output"
+from = "trigger.my_buildkite_org"
+to = "scaler.noop"
+[connect.transform]
+method = "go_template"
+template = """
+{
+  "asg_name": "{{ .queue }}",
+  "desired_count": {{ .scheduled_jobs_count }}
+}
+"""`
+
+const testcase2 = `
+[[trigger]]
+type = "cron"
+id = "global_cron"
+expression = "*/1 * * * *"
+
+[[trigger]]
+type = "buildkite"
+id = "buildkite_1"
+filter_by_queue_name = "aws-on-demand-arm64-ubuntu-.*-ami-.*"
+# set BUILDKITE_TOKEN environment variable
+
+[[trigger]]
+type = "buildkite"
+id = "buildkite_2"
+filter_by_queue_name = "aws-on-demand-arm64-ubuntu-.*-ami-.*"
+# set BUILDKITE_TOKEN environment variable
+
+[[connect]]
+type = "direct"
+id = "connect_cron_to_buildkite_1"
+from = "trigger.global_cron"
+to = "trigger.buildkite_1"
+
+[[connect]]
+type = "direct"
+id = "connect_buildkite_1_to_buildkite_2"
+from = "trigger.buildkite_1"
+to = "trigger.buildkite_2"
+
+[[scaler]]
+type = "noop"
+id = "noop"
+
+[[connect]]
+type = "direct"
+id = "connect_buildkite_1_to_noop"
+from = "trigger.buildkite_1"
+to = "scaler.noop"
+
+[[connect]]
+type = "direct"
+id = "connect_buildkite_2_to_noop"
+from = "trigger.buildkite_2"
+to = "scaler.noop"`
+
+const testcase3 = `
+[[trigger]]
+type = "cron"
+id = "global_cron"
+expression = "*/1 * * * *"
+
+[[trigger]]
+type = "buildkite"
+id = "buildkite"
+filter_by_queue_name = "aws-on-demand-arm64-ubuntu-.*-ami-.*"
+# set BUILDKITE_TOKEN environment variable
+
+[[connect]]
+type = "direct"
+id = "connect_cron_to_buildkite"
+from = "trigger.global_cron"
+to = "trigger.buildkite"
+
+[[connect]]
+type = "direct"
+id = "connect_buildkite_to_itself"
+from = "trigger.buildkite"
+to = "trigger.buildkite"
+
+[[scaler]]
+type = "noop"
+id = "noop"`
+
+const testcase4 = `
+[[trigger]]
+type = "cron"
+id = "global_cron"
+expression = "*/1 * * * *"
+
+[[trigger]]
+type = "buildkite"
+id = "buildkite_1"
+filter_by_queue_name = "aws-on-demand-arm64-ubuntu-.*-ami-.*"
+# set BUILDKITE_TOKEN environment variable
+
+[[trigger]]
+type = "buildkite"
+id = "buildkite_2"
+filter_by_queue_name = "aws-on-demand-arm64-ubuntu-.*-ami-.*"
+# set BUILDKITE_TOKEN environment variable
+
+[[connect]]
+type = "direct"
+id = "connect_cron_to_buildkite_1"
+from = "trigger.global_cron"
+to = "trigger.buildkite_1"
+
+[[connect]]
+type = "direct"
+id = "connect_buildkite_1_to_buildkite_2"
+from = "trigger.buildkite_1"
+to = "trigger.buildkite_2"
+
+[[connect]]
+type = "direct"
+id = "connect_buildkite_2_to_buildkite_1"
+from = "trigger.buildkite_2"
+to = "trigger.buildkite_1"
+
+[[scaler]]
+type = "noop"
+id = "noop"
+
+[[connect]]
+type = "direct"
+id = "connect_buildkite_2_to_noop"
+from = "trigger.buildkite_2"
+to = "trigger.noop"`
+
+func TestVerifyDAG(t *testing.T) {
+	tt := []struct {
+		conf         string
+		isDAG        bool
+		expectsError bool
+	}{
+		{
+			conf:  testcase1,
+			isDAG: true,
+		},
+		{
+			conf:  testcase2,
+			isDAG: true,
+		},
+		{
+			conf:  testcase3,
+			isDAG: false,
+		},
+		{
+			conf:  testcase4,
+			isDAG: false,
+		},
+	}
+
+	for i, tc := range tt {
+		connectors, err := extractConnectors(tc.conf)
+		if err != nil {
+			t.Error("Exracting connectors returned errors")
+		}
+
+		if tc.isDAG != verifyDAG(connectors) {
+			isDag := "false"
+			if tc.isDAG {
+				isDag = "true"
+			}
+			resultString := fmt.Sprintf("testcase%d: isDAG: %s but returned otherwise", i, isDag)
+			t.Errorf("Failed to correctly verify DAG: %s", resultString)
+		}
+	}
+}
+
+func extractConnectors(conf string) (map[string]connector.Interface, error) {
+	var kt = koanf.New(".")
+	var errs []error
+
+	// read waymond config file
+	if err := kt.Load(rawbytes.Provider([]byte(conf)), toml.Parser()); err != nil {
+		return nil, err
+	}
+
+	// track available connector configuration parsers available out of the box in waymond
+	connectorConfigParsers := make(map[connector.Type]func(*koanf.Koanf) (connector.Interface, error))
+	connectorConfigParsers[direct.Type] = direct.ParseConfig
+
+	// extract connector from connector configurations
+	connectorConfigs := kt.Slices("connect")
+	connectors := make(map[string]connector.Interface)
+	for _, connectorConfig := range connectorConfigs {
+		ttype := connectorConfig.String("type")
+		if ttype == "" {
+			errs = append(errs, fmt.Errorf("expected a non-empty 'type' field for connector: %+v", connectorConfig))
+			continue
+		}
+
+		id := connectorConfig.String("id")
+		if id == "" {
+			errs = append(errs, fmt.Errorf("expected a non-empty 'id' field for connector: %+v", connectorConfig))
+			continue
+		}
+
+		parseConfig, found := connectorConfigParsers[connector.Type(ttype)]
+		if !found {
+			errs = append(errs, fmt.Errorf("unknown 'type' value in connector: %s in %+v", ttype, connectorConfig))
+			continue
+		}
+
+		connector, err := parseConfig(connectorConfig)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		connectors[id] = connector
+	}
+	if len(errs) > 0 {
+		return nil, errors.New("Error Extracting connectors from the config file")
+	}
+
+	return connectors, nil
+}

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -11,4 +11,7 @@ type Interface interface {
 	// It is executed exactly once for a given connection
 	// i.e. when waymond boots up
 	Register(ctx context.Context) error
+
+	From() string
+	To() string
 }

--- a/internal/connector/direct/direct.go
+++ b/internal/connector/direct/direct.go
@@ -73,3 +73,11 @@ func ParseConfig(k *koanf.Koanf) (connector.Interface, error) {
 
 	return c, nil
 }
+
+func (c *Connector) To() string {
+	return c.to
+}
+
+func (c *Connector) From() string {
+	return c.from
+}


### PR DESCRIPTION
@scriptnull 

This PR addresses issue #15 by implementing and providing the following four test cases:

1) Valid DAG
![1_valid_dag](https://github.com/user-attachments/assets/5c3e3765-7125-4164-b5ab-e524d9a361d1)

2) Valid DAG
![2_valid_dag](https://github.com/user-attachments/assets/7dbc4923-2bc9-4bf9-94dc-405d58808a96)

3) Invalid DAG
![3_invalid_dag](https://github.com/user-attachments/assets/814b9e8e-cfcb-4701-81c3-8308bc3c1a72)

4) Invalid DAG
![4_invalid_dag](https://github.com/user-attachments/assets/a69598da-2281-49ee-ba65-023810faae66)

To maintain the encapsulation of the `Connector` struct, I kept the fields unexported. However, I introduced the following two methods to the `Connector` interface:

```go
From() string
```

```go
To() string
```
I have successfully run the tests locally and confirmed that everything is working as expected. Please feel free to review and suggest any improvements or changes. I apologize in advance for any oversights.

